### PR TITLE
Fix serializzazione Symbol (font, colori)

### DIFF
--- a/src/File.cpp
+++ b/src/File.cpp
@@ -388,8 +388,7 @@ int File::remoteUpdate(const Symbol &sym) {
     auto pos = symbolById(sym.getSymbolId());
     auto &symbol = pos.second;
 
-    symbol.setChar(sym.getChar());
-    symbol.setFormat(sym.getFormat());
+    symbol.update(sym);
 
     return pos.first;
   }

--- a/src/Symbol.h
+++ b/src/Symbol.h
@@ -86,8 +86,11 @@ public:
 private:
   void checkAndAssign(const QJsonObject &json, bool readPos = true);
   std::string posToString() const; //TODO vedi se rimuovere
+
   static QBrush jsonArrayToBrush(const QJsonArray &array);
   static QJsonArray brushToJsonArray(const QBrush &b);
+  static QFont jsonArrayToFont(const QJsonArray &array);
+  static QJsonArray fontToJsonArray(const QFont &b);
 
   SymbolId _id;
   QChar _char;


### PR DESCRIPTION
- serializzazione colori: finalmente risolto sto cazzo di sfondo nero.
  - i colori sono ora serializzati tramite un QByteArray, il pro è che ora la trasmissione dei colori è molto più accurata, il contro è che si trasmettono più byte
- serializzazione font: uguale
  - risolve errori di conversione

- fix conversione char. A volte incollando il testo preso da qualche altra parte viene copiato in più un carattere NULL (non so perchè, ma amen), e il server crashava perchè non accettavo quel valore.
  - TODO modificare il client per cancellare quel carattere